### PR TITLE
Fix production API URLs - use apiClient service instead of hardcoded.

### DIFF
--- a/src/components/BackendStatus.vue
+++ b/src/components/BackendStatus.vue
@@ -1,8 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
-import axios from 'axios';
-
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+import apiClient from '@/services/services';
 
 const status = ref('checking');
 const lastChecked = ref(null);
@@ -37,7 +35,7 @@ async function checkStatus() {
   
   try {
     // Try main API endpoint first
-    const response = await axios.get(`${API_BASE}/api/courses`, {
+    const response = await apiClient.get('/api/courses', {
       params: { department: 'CS' },
       timeout: 2000
     });

--- a/src/views/CourseCatalog.vue
+++ b/src/views/CourseCatalog.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed, watch } from "vue";
 import CourseServices from "../services/courseServices";
 import CourseCard from "../components/CourseCard.vue";
+import apiClient from "@/services/services";
 
 const searchQuery = ref("");
 const courses = ref([]);
@@ -37,11 +38,8 @@ const searchCourses = async () => {
       params.maxLevel = selectedLevel.value === "400" ? "999" : String(parseInt(selectedLevel.value) + 99);
     }
 
-    const response = await fetch(
-      `http://localhost:8080/api/courses?${new URLSearchParams(params)}`
-    );
-    const data = await response.json();
-    courses.value = data;
+    const response = await apiClient.get("/api/courses", { params });
+    courses.value = response.data;
   } catch (error) {
     console.error("Error searching courses:", error);
     courses.value = [];
@@ -67,9 +65,8 @@ watch([searchQuery, selectedDepartment, selectedLevel], () => {
 
 const loadDepartments = async () => {
   try {
-    const response = await fetch("http://localhost:8080/api/courses/departments");
-    const data = await response.json();
-    departments.value = data.map(dept => ({ title: dept, value: dept }));
+    const response = await apiClient.get("/api/courses/departments");
+    departments.value = response.data.map(dept => ({ title: dept, value: dept }));
     departments.value.unshift({ title: "All Departments", value: "" });
   } catch (error) {
     console.error("Error loading departments:", error);


### PR DESCRIPTION
fix: production API URLs to use apiclient service instead of hardcoded localhost